### PR TITLE
upgrade alpine version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.9
 
 RUN apk add --update \
   bash \

--- a/backup.sh
+++ b/backup.sh
@@ -51,6 +51,10 @@ backup() {
 }
 
 upload_to_gcs() {
+  if [[ ! "$GCS_BUCKET" =~ gs://* ]]; then
+    GCS_BUCKET="gs://${GCS_BUCKET}"
+  fi
+
   if [[ $GCS_KEY_FILE_PATH != "" ]]
   then
 cat <<EOF > $BOTO_CONFIG_PATH

--- a/chart/mongodb-gcs-backup/values.yaml
+++ b/chart/mongodb-gcs-backup/values.yaml
@@ -11,6 +11,10 @@ resources: {}
 #    cpu: 100m
 #    memory: 128Mi
 
+env: {}
+# - name: GCS_BUCKET
+#   value: "gs://bucket-name/path"
+
 concurrencyPolicy: Forbid
 failedJobsHistoryLimit: 1
 restartPolicy: OnFailure


### PR DESCRIPTION
With alpine:3.7 I'm getting errors in mongodump with `mongo:latest` version 

Also made a small change in `backup.sh` to check schema `gs://` in bucket and added a env sample in values.yaml

Can you approve this PR and update your docker image? 

Thank you 