### PR TITLE
New version of Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,15 @@
-FROM alpine:3.7
+FROM mongo:latest
 
-RUN apk add --update \
+RUN apt-get update && apt-get install -y \
   bash \
-  mongodb-tools \
-  curl \
-  python \
-  py-pip \
-  py-cffi \
-  && pip install --upgrade pip \
-  && apk add --virtual build-deps \
-  gcc \
-  libffi-dev \
-  python-dev \
-  linux-headers \
-  musl-dev \
-  openssl-dev \
-  && pip install gsutil \
-  && apk del build-deps \
-  && rm -rf /var/cache/apk/*
+  curl
+
+RUN echo "deb http://packages.cloud.google.com/apt cloud-sdk-xenial main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+  curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
+  apt-get update && \
+  apt-get install -y google-cloud-sdk
 
 ADD ./backup.sh /mongodb-gcs-backup/backup.sh
-WORKDIR /mongodb-gcs-backup
 
 RUN chmod +x /mongodb-gcs-backup/backup.sh
 


### PR DESCRIPTION
Hello :)! 

I've just updated the Dockerfile to use the mongo:latest official image as base image while trying to fix some strange issues while doing a backup over a mongodb replicaset with authentication enabled. 

It seems that to have the latest mongo-tools installed fixed my issue.

Also, I simplified the way to install the SDK (and gsutil) using the Google recommended way.